### PR TITLE
Update flipper_game_connect_wires.c

### DIFF
--- a/games/connect_wires/flipper_game_connect_wires.c
+++ b/games/connect_wires/flipper_game_connect_wires.c
@@ -665,6 +665,8 @@ int32_t flipper_game_connect_wires(void* p) {
         }
 
         furi_mutex_release(appState->mutex);
+        view_port_update(view_port);
+      
     }
 
     free(appState);


### PR DESCRIPTION
App was not receiving GUI updates when launched from Desktop. Added view_port_update to the main game loop.

Replicate Bug: Make Connect Wires game a favorite (i.e. long press left on Desktop to launch game). Game menu displays but screen never updates.