### PR TITLE
freed appState->mutex memory leak

### DIFF
--- a/games/connect_wires/flipper_game_connect_wires.c
+++ b/games/connect_wires/flipper_game_connect_wires.c
@@ -731,7 +731,8 @@ int32_t flipper_game_connect_wires(void* p) {
         furi_mutex_release(appState->mutex);
     }
 
-    free(appState);
+    free(appState->mutex);
+	free(appState);
 
     furi_message_queue_free(event_queue);
 


### PR DESCRIPTION
Found a bug in your app after I found and fixed the exact same bug in my kcline app. appState->mutex is allocated but never freed, and it leads to a memory leak. Sorry I didn't catch this before! Also sorry for the formatting issue, not sure what is going on there, it doesn't look like that in Vim, but shows up on GitHub, so I must have a goofy setting that needs changed.

2998244 [E][FuriThread] Connect Wires allocation balance: 88
2998258 [I][Loader] App returned: 0
``2998262 [I][Loader] Application stopped. Free heap: 145952``
3013617 [I][Loader] Loading /ext/apps/Games/game_connect_wires.fap
3015991 [E][FuriThread] Connect Wires allocation balance: 88
``3016009 [I][Loader] Application stopped. Free heap: 139688``
